### PR TITLE
removed session scope on 3 methods (pytest_selenium._verify_url, safet…

### DIFF
--- a/pytest_selenium/pytest_selenium.py
+++ b/pytest_selenium/pytest_selenium.py
@@ -57,7 +57,7 @@ def base_url(request):
         return base_url
 
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture
 def _verify_url(request, base_url):
     """Verifies the base URL"""
     verify = request.config.option.verify_base_url

--- a/pytest_selenium/safety.py
+++ b/pytest_selenium/safety.py
@@ -29,7 +29,7 @@ def pytest_configure(config):
         'accidentally.')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def sensitive_url(request, base_url):
     """Return the first sensitive URL from response history of the base URL"""
     if not base_url:
@@ -60,7 +60,7 @@ def sensitive_url(request, base_url):
         return first_match.string
 
 
-@pytest.fixture(scope='function', autouse=True)
+@pytest.fixture
 def _skip_sensitive(request, sensitive_url):
     """Skip destructive tests if the environment is considered sensitive"""
     destructive = 'nondestructive' not in request.node.keywords


### PR DESCRIPTION
I found compatibility issues when using pytest-selenium with pytest-tornado.
Running the pytest-tornado with pytest-selenium installed would crash:
https://github.com/eugeniy/pytest-tornado
With the scope removed, everything should be working again.