### PR TITLE
fix issue: AttributeError: 'module' object has no attribute 'ie'

### DIFF
--- a/pytest_selenium/drivers/__init__.py
+++ b/pytest_selenium/drivers/__init__.py
@@ -1,1 +1,1 @@
-from . import internet_explorer as ie
+from . import internet_explorer as ie  # noqa

--- a/pytest_selenium/drivers/__init__.py
+++ b/pytest_selenium/drivers/__init__.py
@@ -1,0 +1,1 @@
+from . import internet_explorer as ie

--- a/pytest_selenium/pytest_selenium.py
+++ b/pytest_selenium/pytest_selenium.py
@@ -20,7 +20,7 @@ SUPPORTED_DRIVERS = [
     'BrowserStack',
     'Chrome',
     'Firefox',
-    'IE',
+    'Ie',
     'PhantomJS',
     'Remote',
     'Safari',


### PR DESCRIPTION
To fix error: AttributeError: 'module' object has no attribute 'ie' when using --driver IE 