### PR TITLE
[WIP] Module-scoped fixtures

### DIFF
--- a/pytest_selenium/drivers/firefox.py
+++ b/pytest_selenium/drivers/firefox.py
@@ -49,7 +49,7 @@ def firefox_path(request):
     return request.config.getoption('firefox_path')
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def firefox_profile(request):
     profile = FirefoxProfile(request.config.getoption('firefox_profile'))
     for preference in request.config.getoption('firefox_preferences'):


### PR DESCRIPTION
Work in progress: checking Travis results

The aim of this PR is to permit keeping the browser open between test-cases, instead of open and close it for each test case.
The proposed solution is to make the selenium fixture module-scoped instead of function-scoped.