### PR TITLE
Update selenium to session level

### DIFF
--- a/pytest_selenium/drivers/firefox.py
+++ b/pytest_selenium/drivers/firefox.py
@@ -41,7 +41,7 @@ def driver_kwargs(capabilities, driver_path, firefox_options, **kwargs):
     return kwargs
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def firefox_options(request, firefox_path, firefox_profile):
     options = Options()
     options.profile = firefox_profile
@@ -55,7 +55,7 @@ def firefox_path(request):
     return request.config.getoption('firefox_path')
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def firefox_profile(request):
     profile = FirefoxProfile(request.config.getoption('firefox_profile'))
     for preference in request.config.getoption('firefox_preferences'):

--- a/pytest_selenium/pytest_selenium.py
+++ b/pytest_selenium/pytest_selenium.py
@@ -60,7 +60,7 @@ def session_capabilities(request, variables):
     return capabilities
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def capabilities(request, session_capabilities):
     """Returns combined capabilities"""
     capabilities = copy.deepcopy(session_capabilities)  # make a copy
@@ -71,7 +71,7 @@ def capabilities(request, session_capabilities):
     return capabilities
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def driver_kwargs(request, capabilities, driver_class, driver_path,
                   firefox_options, firefox_profile):
     kwargs = {}
@@ -88,7 +88,7 @@ def driver_kwargs(request, capabilities, driver_class, driver_path,
     return kwargs
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def driver_class(request):
     driver = request.config.getoption('driver')
     if driver is None:
@@ -96,12 +96,12 @@ def driver_class(request):
     return getattr(webdriver, driver, webdriver.Remote)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def driver_path(request):
     return request.config.getoption('driver_path')
 
 
-@pytest.yield_fixture
+@pytest.yield_fixture(scope="session")
 def driver(request, driver_class, driver_kwargs):
     """Returns a WebDriver instance based on options and capabilities"""
     driver = driver_class(**driver_kwargs)
@@ -120,7 +120,7 @@ def driver(request, driver_class, driver_kwargs):
     driver.quit()
 
 
-@pytest.yield_fixture
+@pytest.yield_fixture(scope="session")
 def selenium(driver):
     yield driver
 


### PR DESCRIPTION
Having selenium setup and tear down each time a test is ran is
expensive. Set selenium driver instead to be applied at the session-level.