### PR TITLE
Initial attempt at adding geckodriver logs

### DIFF
--- a/pytest_selenium/drivers/firefox.py
+++ b/pytest_selenium/drivers/firefox.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import warnings
+import os
 
 import pytest
 from selenium.webdriver import FirefoxProfile
@@ -33,12 +34,15 @@ def pytest_addoption(parser):
                      help='path to a firefox extension.')
 
 
-def driver_kwargs(capabilities, driver_path, firefox_options, **kwargs):
+def driver_kwargs(capabilities, driver_path, firefox_options, log_path,
+                  pytestconfig, **kwargs):
     kwargs = {}
     if capabilities:
         kwargs['capabilities'] = capabilities
     if driver_path is not None:
         kwargs['executable_path'] = driver_path
+    log_path = os.path.realpath('geckodriver.log')
+    kwargs['log_path'] = pytestconfig._driver_log = log_path
     kwargs['firefox_options'] = firefox_options
     return kwargs
 

--- a/pytest_selenium/pytest_selenium.py
+++ b/pytest_selenium/pytest_selenium.py
@@ -59,7 +59,8 @@ def driver_args():
 
 @pytest.fixture
 def driver_kwargs(request, capabilities, chrome_options, driver_args,
-                  driver_class, driver_path, firefox_options, firefox_profile):
+                  driver_class, driver_path, firefox_options, firefox_profile,
+                  pytestconfig):
     kwargs = {}
     driver = request.config.getoption('driver').lower()
     kwargs.update(getattr(drivers, driver).driver_kwargs(
@@ -72,6 +73,8 @@ def driver_kwargs(request, capabilities, chrome_options, driver_args,
         host=request.config.getoption('host'),
         port=request.config.getoption('port'),
         request=request,
+        log_path=None,
+        pytestconfig=pytestconfig,
         test='.'.join(split_class_and_test_names(request.node.nodeid))))
     return kwargs
 
@@ -206,6 +209,11 @@ def _gather_html(item, report, driver, summary, extra):
 
 
 def _gather_logs(item, report, driver, summary, extra):
+    pytest_html = item.config.pluginmanager.getplugin('html')
+    if hasattr(item.config, '_driver_log'):
+        with open(item.config._driver_log, 'r') as driver_log:
+            extra.append(pytest_html.extras.text(
+                driver_log.read(), 'Driver Log'))
     try:
         types = driver.log_types
     except Exception as e:
@@ -219,7 +227,6 @@ def _gather_logs(item, report, driver, summary, extra):
             summary.append('WARNING: Failed to gather {0} log: {1}'.format(
                 name, e))
             return
-        pytest_html = item.config.pluginmanager.getplugin('html')
         if pytest_html is not None:
             extra.append(pytest_html.extras.text(
                 format_log(log), '%s Log' % name.title()))

--- a/testing/test_report.py
+++ b/testing/test_report.py
@@ -145,3 +145,10 @@ def test_exclude_debug_config(testdir, httpserver, monkeypatch, exclude):
         assert re.search(HTML_REGEX, html) is None
     else:
         assert re.search(HTML_REGEX, html) is not None
+
+
+def test_driver_log(testdir, httpserver):
+    driver_log_regex = '<a class="text" href=".*" target="_blank">Driver Log</a>' #noqa
+    httpserver.serve_content(content='<h1>Success!</h1><p>Ё</p>')
+    result, html = run(testdir)
+    assert re.search(driver_log_regex, html) is not None

--- a/testing/test_report.py
+++ b/testing/test_report.py
@@ -148,7 +148,7 @@ def test_exclude_debug_config(testdir, httpserver, monkeypatch, exclude):
 
 
 def test_driver_log(testdir, httpserver):
-    driver_log_regex = '<a class="text" href=".*" target="_blank">Driver Log</a>' #noqa
+    driver_log_regex = '<a class="text" href=".*" target="_blank">Driver Log</a>'  # noqa
     httpserver.serve_content(content='<h1>Success!</h1><p>Ё</p>')
     result, html = run(testdir)
     assert re.search(driver_log_regex, html) is not None


### PR DESCRIPTION
@davehunt 
I have made an attempt at solving Issue #108.

The logs will appear in a link tab named ```Geckodriver log```. If the log is not available it is printed out. I think this could get annoying however.

I also moved the variable that sets up ```pytest-html``` to the top of the ```_gather_logs``` function since I use that in the geckodriver log append as well.