### PR TITLE
Add Python 3.6 classifier to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,5 +50,6 @@ setup(name='pytest-selenium',
           'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: Implementation :: CPython',
           'Programming Language :: Python :: Implementation :: PyPy'])


### PR DESCRIPTION
Add Python 3.6 classifier to setup.py.

3.6 is currently being used for testing, but the latest supported release per the classifiers is 3.5.