### PR TITLE
Fix dead link in user guide

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -35,7 +35,7 @@ Configuration Files
 There are a number of options and values that can be set in an INI-style
 configuration file. For details of the expected name, format, and location of
 these configuration files, check the
-`pytest documentation <http://pytest.org/latest/customize.html#command-line-options-and-configuration-file-settings>`_.
+`pytest documentation <http://pytest.org/en/latest/customize.html#command-line-options-and-configuration-file-settings>`_.
 
 
 Specifying a Base URL


### PR DESCRIPTION
The old link is dead and leads to an "does not exist yet" page. The new link redirects to:

https://docs.pytest.org/en/latest/customize.html#command-line-options-and-configuration-file-settings

Should I add that one instead?