### PR TITLE
Doc base url sensitive env

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -44,6 +44,12 @@ Specifying a Base URL
 To specify a base URL, refer to the documentation for the
 `pytest-base-url <https://github.com/pytest-dev/pytest-base-url>`_ plugin.
 
+.. note::
+
+  By default, any tests using a base URL will be skipped. This is because all tests
+  are considered destructive, and all environments are considered sensitive. See
+  `Sensitive Environments`_ for further details.
+
 Sensitive Environments
 **********************
 

--- a/pytest_selenium/safety.py
+++ b/pytest_selenium/safety.py
@@ -33,7 +33,13 @@ def pytest_configure(config):
 
 
 def pytest_report_header(config, startdir):
-    return 'sensitiveurl: {0}'.format(config.getoption('sensitive_url'))
+    base_url = config.getoption('base_url')
+    sensitive_url = config.getoption('sensitive_url')
+    msg = 'sensitiveurl: {0}'.format(config.getoption('sensitive_url'))
+    if base_url and sensitive_url and re.match(sensitive_url, base_url):
+        msg += '\nwarning: base URL ({}) matches sensitive URL ({})'\
+            .format(base_url, sensitive_url)
+    return msg
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
- Improve documentation about base URL
- Print a message if tests are skipped because of a sensitive URL. Currently, for this to work, the user needs to use the `-s` option. If you have a better solution, please tell me.