### PR TITLE
Fix exception when html plugin is not available

### DIFF
--- a/pytest_selenium/pytest_selenium.py
+++ b/pytest_selenium/pytest_selenium.py
@@ -228,7 +228,7 @@ def _gather_html(item, report, driver, summary, extra):
 def _gather_logs(item, report, driver, summary, extra):
     pytest_html = item.config.pluginmanager.getplugin('html')
     if item.config._driver_log and os.path.exists(item.config._driver_log):
-        if pytest_html:
+        if pytest_html is not None:
             with open(item.config._driver_log, 'r') as f:
                 extra.append(pytest_html.extras.text(f.read(), 'Driver Log'))
         summary.append('Driver log: {0}'.format(item.config._driver_log))

--- a/pytest_selenium/pytest_selenium.py
+++ b/pytest_selenium/pytest_selenium.py
@@ -228,8 +228,9 @@ def _gather_html(item, report, driver, summary, extra):
 def _gather_logs(item, report, driver, summary, extra):
     pytest_html = item.config.pluginmanager.getplugin('html')
     if item.config._driver_log and os.path.exists(item.config._driver_log):
-        with open(item.config._driver_log, 'r') as f:
-            extra.append(pytest_html.extras.text(f.read(), 'Driver Log'))
+        if pytest_html:
+            with open(item.config._driver_log, 'r') as f:
+                extra.append(pytest_html.extras.text(f.read(), 'Driver Log'))
         summary.append('Driver log: {0}'.format(item.config._driver_log))
     try:
         types = driver.log_types


### PR DESCRIPTION
This should make e.g. the errors here more intelligible: https://travis-ci.org/mozilla/treeherder/jobs/269652938

I assume there are just some configurations where the html plugin is not used/available, given that there is other logic in the same function which is conditional in the same way that I am proposing.