### PR TITLE
Fix a DeprecationWarning on selenium >= 3.8.0.

### DIFF
--- a/pytest_selenium/drivers/chrome.py
+++ b/pytest_selenium/drivers/chrome.py
@@ -1,8 +1,10 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from distutils.version import LooseVersion
 
 import pytest
+from selenium import __version__ as SELENIUM_VERSION
 from selenium.webdriver.chrome.options import Options
 
 
@@ -10,7 +12,14 @@ def driver_kwargs(capabilities, driver_args, driver_log, driver_path,
                   chrome_options, **kwargs):
     kwargs = {
         'desired_capabilities': capabilities,
-        'chrome_options': chrome_options}
+    }
+
+    # Selenium 3.8.0 deprecated chrome_options in favour of options
+    if LooseVersion(SELENIUM_VERSION) < LooseVersion('3.8.0'):
+        kwargs['chrome_options'] = chrome_options
+    else:
+        kwargs['options'] = chrome_options
+
     if driver_args is not None:
         kwargs['service_args'] = driver_args
     if driver_log is not None:

--- a/pytest_selenium/drivers/firefox.py
+++ b/pytest_selenium/drivers/firefox.py
@@ -1,10 +1,11 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
+from distutils.version import LooseVersion
 import warnings
 
 import pytest
+from selenium import __version__ as SELENIUM_VERSION
 from selenium.webdriver import FirefoxProfile
 from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 from selenium.webdriver.firefox.options import Options
@@ -54,7 +55,12 @@ def driver_kwargs(capabilities, driver_log, driver_path, firefox_options,
         kwargs['log_path'] = driver_log
     if driver_path is not None:
         kwargs['executable_path'] = driver_path
-    kwargs['firefox_options'] = firefox_options
+
+    # Selenium 3.8.0 deprecated firefox_options in favour of options
+    if LooseVersion(SELENIUM_VERSION) < LooseVersion('3.8.0'):
+        kwargs['firefox_options'] = firefox_options
+    else:
+        kwargs['options'] = firefox_options
     return kwargs
 
 


### PR DESCRIPTION
Selenium 3.8.0 has deprecated `chrome_options`, so we should use `options` instead.