### PR TITLE
Implementation of SauceLabs job auth options

### DIFF
--- a/pytest_selenium/pytest_selenium.py
+++ b/pytest_selenium/pytest_selenium.py
@@ -303,6 +303,12 @@ def pytest_addoption(parser):
                   help='debug to exclude from capture',
                   default=os.getenv('SELENIUM_EXCLUDE_DEBUG'))
 
+    _auth_choices = ('none', 'token', 'hour', 'day')
+    parser.addini('saucelabs_job_auth',
+                  help='Authorization for the SauceLabs job {0}'.
+                  format(_auth_choices),
+                  default=os.getenv('SAUCELABS_JOB_AUTH', 'token'))
+
     group = parser.getgroup('selenium', 'selenium')
     group._addoption('--driver',
                      action=DriverAction,


### PR DESCRIPTION
Just the implementation. Will add docs in the next commit.

As far as tests goes. Is it even possible? It would require me to access the `summary` from the `pytest_selenium_runtest_makereport` hook, and check for the presence of a correct url. At least for the `none` and `token` (default) options.