### PR TITLE
Use https, rather than http for API and job URLs

### DIFF
--- a/pytest_selenium/drivers/saucelabs.py
+++ b/pytest_selenium/drivers/saucelabs.py
@@ -14,8 +14,8 @@ from pytest_selenium.drivers.cloud import Provider
 
 class SauceLabs(Provider):
 
-    API = 'http://saucelabs.com/rest/v1/{username}/jobs/{session}'
-    JOB = 'http://saucelabs.com/jobs/{session}'
+    API = 'https://saucelabs.com/rest/v1/{username}/jobs/{session}'
+    JOB = 'https://saucelabs.com/jobs/{session}'
 
     @property
     def auth(self):
@@ -23,7 +23,7 @@ class SauceLabs(Provider):
 
     @property
     def executor(self):
-        return 'http://{0}:{1}@ondemand.saucelabs.com:80/wd/hub'.format(
+        return 'https://{0}:{1}@ondemand.saucelabs.com:80/wd/hub'.format(
             self.username, self.key)
 
     @property

--- a/pytest_selenium/drivers/saucelabs.py
+++ b/pytest_selenium/drivers/saucelabs.py
@@ -23,7 +23,7 @@ class SauceLabs(Provider):
 
     @property
     def executor(self):
-        return 'https://{0}:{1}@ondemand.saucelabs.com:80/wd/hub'.format(
+        return 'https://{0}:{1}@ondemand.saucelabs.com/wd/hub'.format(
             self.username, self.key)
 
     @property

--- a/testing/test_saucelabs.py
+++ b/testing/test_saucelabs.py
@@ -91,7 +91,7 @@ def test_auth_token(monkeypatch, auth_type, auth_token):
     monkeypatch.setenv('SAUCELABS_API_KEY', 'bar')
 
     session_id = '12345678'
-    url = 'http://saucelabs.com/jobs/{}'.format(session_id)
+    url = 'https://saucelabs.com/jobs/{}'.format(session_id)
 
     if auth_type != 'none':
         url += '?auth={}'.format(auth_token)


### PR DESCRIPTION
All the API/job, etc. URLs I've seen on Sauce Labs' documentation use HTTPS; I'm not sure if this is the right change, but it seems safe, and preferred?

https://wiki.saucelabs.com/display/DOCS/Accessing+the+API

@davehunt r?