### PR TITLE
replace saucelabs remote url with http instead of https

### DIFF
--- a/pytest_selenium/drivers/saucelabs.py
+++ b/pytest_selenium/drivers/saucelabs.py
@@ -24,7 +24,7 @@ class SauceLabs(Provider):
 
     @property
     def executor(self):
-        return 'https://{0}:{1}@ondemand.saucelabs.com/wd/hub'.format(
+        return 'http://{0}:{1}@ondemand.saucelabs.com/wd/hub'.format(
             self.username, self.key)
 
     @property


### PR DESCRIPTION
Using the original URL to the Sauce Labs remote server throws an SSL exception with Python 3. One way to work around this issue is to use an HTTP URL instead of the HTTPS version.