### PR TITLE
Remove deprecated fixture decorators

### DIFF
--- a/pytest_selenium/pytest_selenium.py
+++ b/pytest_selenium/pytest_selenium.py
@@ -184,7 +184,7 @@ def driver_path(request):
     return request.config.getoption("driver_path")
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def driver(request, driver_class, driver_kwargs):
     """Returns a WebDriver instance based on options and capabilities"""
     driver = driver_class(**driver_kwargs)
@@ -203,7 +203,7 @@ def driver(request, driver_class, driver_kwargs):
     driver.quit()
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def selenium(driver):
     yield driver
 


### PR DESCRIPTION
As of pytest 3.0 the `yield_fixture` decorators are deprecated in favor
of the "regular" `fixture`.

Resolves: #198 