### PR TITLE
Add TestingBot video to html report correctly

### DIFF
--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -43,7 +43,7 @@ def testdir(request, httpserver_base_url):
         filterwarnings =
             error::DeprecationWarning
             ignore:--firefox-\w+ has been deprecated:DeprecationWarning
-    """,
+    """,  # noqa: W605
     )
 
     def runpytestqa(*args, **kwargs):

--- a/testing/test_report.py
+++ b/testing/test_report.py
@@ -132,7 +132,7 @@ def test_exclude_debug_env(testdir, httpserver, monkeypatch, exclude):
 
 
 @pytest.mark.parametrize("exclude", ["url", "screenshot", "html", "logs"])
-def test_exclude_debug_config(testdir, httpserver, monkeypatch, exclude):
+def test_exclude_debug_config(testdir, httpserver, exclude):
     httpserver.serve_content(content="<h1>Success!</h1><p>Ё</p>")
     testdir.makefile(
         ".ini",


### PR DESCRIPTION
TestingBot now provides a direct link to the video (regardless of if it has finished rendering). 
https://testingbot.com/support/other/sharing