### PR TITLE
Require pytest 3.6 and cleanup of get_markers code

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+1.16.0 (unreleased)
+-------------------
+
+* ``pytest-selenium`` now requires pytest 3.6 or later.
+
 1.15.1 (2019-01-07)
 -------------------
 

--- a/pytest_selenium/drivers/cloud.py
+++ b/pytest_selenium/drivers/cloud.py
@@ -38,18 +38,3 @@ class Provider(object):
 
     def uses_driver(self, driver):
         return driver.lower() == self.name.lower()
-
-
-def get_markers(node):
-    # `MarkInfo` is removed in pytest 4.1.0
-    # see https://github.com/pytest-dev/pytest/pull/4564
-    try:
-        from _pytest.mark import MarkInfo
-
-        keywords = node.keywords
-        markers = [m for m in keywords.keys() if isinstance(keywords[m], MarkInfo)]
-    except ImportError:
-        # `iter_markers` was introduced in pytest 3.6
-        markers = [m.name for m in node.iter_markers()]
-
-    return markers

--- a/pytest_selenium/drivers/saucelabs.py
+++ b/pytest_selenium/drivers/saucelabs.py
@@ -9,7 +9,7 @@ from py.xml import html
 import pytest
 import requests
 
-from pytest_selenium.drivers.cloud import Provider, get_markers
+from pytest_selenium.drivers.cloud import Provider
 
 
 class SauceLabs(Provider):
@@ -92,7 +92,7 @@ def driver_kwargs(request, test, capabilities, **kwargs):
     _capabilities.setdefault("username", provider.username)
     _capabilities.setdefault("accessKey", provider.key)
     _capabilities.setdefault("name", test)
-    tags = _capabilities.get("tags", []) + get_markers(request.node)
+    tags = _capabilities.get("tags", []) + list(request.node.iter_markers())
     if tags:
         _capabilities["tags"] = tags
 

--- a/pytest_selenium/drivers/testingbot.py
+++ b/pytest_selenium/drivers/testingbot.py
@@ -7,7 +7,7 @@ import pytest
 from py.xml import html
 import requests
 
-from pytest_selenium.drivers.cloud import Provider, get_markers
+from pytest_selenium.drivers.cloud import Provider
 
 HOST = "hub.testingbot.com"
 PORT = 443
@@ -90,7 +90,7 @@ def driver_kwargs(request, test, capabilities, host, port, **kwargs):
     capabilities.setdefault("name", test)
     capabilities.setdefault("client_key", provider.key)
     capabilities.setdefault("client_secret", provider.secret)
-    groups = capabilities.get("groups", []) + get_markers(request.node)
+    groups = capabilities.get("groups", []) + list(request.node.iter_markers())
     if groups:
         capabilities["groups"] = groups
     kwargs = {

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     url="https://github.com/pytest-dev/pytest-selenium",
     packages=["pytest_selenium", "pytest_selenium.drivers"],
     install_requires=[
-        "pytest>=3.0",
+        "pytest>=3.6",
         "pytest-base-url",
         "pytest-html>=1.14.0",
         "pytest-variables>=1.5.0",


### PR DESCRIPTION
Fix #210