### PR TITLE
Deprecate phantom

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 jobs:
   include:
-    - stage: Linting
+    - stage: Tests
+      name: Linting
       python: 3.7
       dist: xenial
       sudo: required
@@ -9,7 +10,8 @@ jobs:
       addons: skip
       env: TOXENV=flake8
 
-    - stage: Docs
+    -
+      name: Docs
       python: 3.7
       dist: xenial
       sudo: required
@@ -17,21 +19,25 @@ jobs:
       addons: skip
       env: TOXENV=docs
 
-    - stage: python 2.7
+    -
+      name: python 2.7
       python: 2.7
       env: TOXENV=py27
 
-    - stage: python 3.6
+    -
+      name: python 3.6
       python: 3.6
       env: TOXENV=py36
 
-    - stage: python 3.7
+    -
+      name: python 3.7
       python: 3.7
       dist: xenial
       sudo: required
       env: TOXENV=py37
 
-    - stage: pypy 5.6.0
+    -
+      name: pypy 5.6.0
       python: pypy-5.6.0
       env: TOXENV=pypy
 

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -26,7 +26,7 @@ Optional packages
 
 Appium
 ~~~~~~
-To install pytest-selenium with `appium <https://appium.io/>`_ support:
+To install pytest-selenium with `Appium <https://appium.io/>`_ support:
 
 .. code-block:: bash
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -218,6 +218,9 @@ option to indicate where it can be found::
 
 PhantomJS
 ---------
+**NOTE:** Support for PhantomJS has been deprecated and will be removed in a
+future release. If running headless is a requirement, please consider using
+Firefox or Chrome instead.
 
 To use PhantomJS, you will need `download it <http://phantomjs.org/download.html>`_
 and specify ``PhantomJS`` for the ``--driver`` command line option. If

--- a/pytest_selenium/drivers/phantomjs.py
+++ b/pytest_selenium/drivers/phantomjs.py
@@ -1,9 +1,16 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import warnings
 
 
 def driver_kwargs(capabilities, driver_args, driver_log, driver_path, **kwargs):
+    warnings.warn(
+        "Support for PhantomJS has been deprecated and will be "
+        "removed in a future release. If running headless is a "
+        "requirement, please consider using Firefox or Chrome instead.",
+        DeprecationWarning,
+    )
     kwargs = {"desired_capabilities": capabilities, "service_log_path": driver_log}
     if driver_args is not None:
         kwargs["service_args"] = driver_args

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -51,6 +51,7 @@ def testdir(request, httpserver_base_url):
         filterwarnings =
             error::DeprecationWarning
             ignore:--firefox-\w+ has been deprecated:DeprecationWarning
+            ignore:Support for PhantomJS:DeprecationWarning
     """,
     )
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,9 @@ envlist = py{27,36,37,py,py3}, docs, flake8
 
 [testenv]
 passenv = PYTEST_ADDOPTS
-setenv = MOZ_HEADLESS=1
+setenv =
+    PYTHONDONTWRITEBYTECODE=1
+    MOZ_HEADLESS=1
 deps =
     pytest-localserver
     pytest-xdist


### PR DESCRIPTION
There is no need for PhantomJS anymore since both Chrome and Firefox support headless testing. I suggest we deprecate it and remove it in the next major release.