### PR TITLE
Avoid importing requests for test runs that don't need it

### DIFF
--- a/pytest_selenium/drivers/browserstack.py
+++ b/pytest_selenium/drivers/browserstack.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import pytest
-import requests
 
 from pytest_selenium.drivers.cloud import Provider
 
@@ -42,6 +41,10 @@ def pytest_selenium_runtest_makereport(item, report, summary, extra):
     passed = report.passed or (report.failed and hasattr(report, "wasxfail"))
     session_id = item._driver.session_id
     api_url = provider.API.format(session=session_id)
+
+    # import requests lazily here to avoid importing
+    # requests for unit tests that don't need it
+    import requests
 
     try:
         job_info = requests.get(api_url, auth=provider.auth, timeout=10).json()

--- a/pytest_selenium/drivers/crossbrowsertesting.py
+++ b/pytest_selenium/drivers/crossbrowsertesting.py
@@ -4,7 +4,6 @@
 
 from py.xml import html
 import pytest
-import requests
 
 from pytest_selenium.drivers.cloud import Provider
 
@@ -40,6 +39,10 @@ def pytest_selenium_capture_debug(item, report, extra):
     if not provider.uses_driver(item.config.getoption("driver")):
         return
 
+    # import requests lazily here to avoid importing
+    # requests for unit tests that don't need it
+    import requests
+
     videos = (
         requests.get(
             provider.API.format(session=item._driver.session_id),
@@ -62,6 +65,10 @@ def pytest_selenium_runtest_makereport(item, report, summary, extra):
         return
 
     passed = report.passed or (report.failed and hasattr(report, "wasxfail"))
+
+    # import requests lazily here to avoid importing
+    # requests for unit tests that don't need it
+    import requests
 
     # Add the test URL to the summary
     info = requests.get(

--- a/pytest_selenium/drivers/saucelabs.py
+++ b/pytest_selenium/drivers/saucelabs.py
@@ -7,7 +7,6 @@ import json
 
 from py.xml import html
 import pytest
-import requests
 
 from pytest_selenium.drivers.cloud import Provider
 
@@ -67,6 +66,10 @@ def pytest_selenium_runtest_makereport(item, report, summary, extra):
     pytest_html = item.config.pluginmanager.getplugin("html")
     # Add the job URL to the HTML report
     extra.append(pytest_html.extras.url(job_url, "{0} Job".format(provider.name)))
+
+    # import requests lazily here to avoid importing
+    # requests for unit tests that don't need it
+    import requests
 
     try:
         # Update the job result

--- a/pytest_selenium/drivers/testingbot.py
+++ b/pytest_selenium/drivers/testingbot.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import pytest
-import requests
 
 from hashlib import md5
 from py.xml import html
@@ -71,6 +70,10 @@ def pytest_selenium_runtest_makereport(item, report, summary, extra):
     pytest_html = item.config.pluginmanager.getplugin("html")
     # Add the job URL to the HTML report
     extra.append(pytest_html.extras.url(job_url, "{0} Job".format(provider.name)))
+
+    # import requests lazily here to avoid importing
+    # requests for unit tests that don't need it
+    import requests
 
     try:
         # Update the job result

--- a/pytest_selenium/pytest_selenium.py
+++ b/pytest_selenium/pytest_selenium.py
@@ -8,9 +8,9 @@ from datetime import datetime
 import os
 import io
 import logging
+from collections.abc import Mapping, MutableMapping
 
 import pytest
-from requests.structures import CaseInsensitiveDict
 from selenium import webdriver
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.support.event_firing_webdriver import EventFiringWebDriver
@@ -18,6 +18,80 @@ from selenium.webdriver.support.event_firing_webdriver import EventFiringWebDriv
 from . import drivers
 
 LOGGER = logging.getLogger(__name__)
+
+
+class CaseInsensitiveDict(MutableMapping):
+    """A case-insensitive ``dict``-like object.
+
+    Implements all methods and operations of
+    ``MutableMapping`` as well as dict's ``copy``. Also
+    provides ``lower_items``.
+
+    All keys are expected to be strings. The structure remembers the
+    case of the last key to be set, and ``iter(instance)``,
+    ``keys()``, ``items()``, ``iterkeys()``, and ``iteritems()``
+    will contain case-sensitive keys. However, querying and contains
+    testing is case insensitive::
+
+        cid = CaseInsensitiveDict()
+        cid['Accept'] = 'application/json'
+        cid['aCCEPT'] == 'application/json'  # True
+        list(cid) == ['Accept']  # True
+
+    For example, ``headers['content-encoding']`` will return the
+    value of a ``'Content-Encoding'`` response header, regardless
+    of how the header name was originally stored.
+
+    If the constructor, ``.update``, or equality comparison
+    operations are given keys that have equal ``.lower()``s, the
+    behavior is undefined.
+    """
+
+    def __init__(self, data=None, **kwargs):
+        self._store = dict()
+        if data is None:
+            data = {}
+        self.update(data, **kwargs)
+
+    def __setitem__(self, key, value):
+        # Use the lowercased key for lookups, but store the actual
+        # key alongside the value.
+        self._store[key.lower()] = (key, value)
+
+    def __getitem__(self, key):
+        return self._store[key.lower()][1]
+
+    def __delitem__(self, key):
+        del self._store[key.lower()]
+
+    def __iter__(self):
+        return (casedkey for casedkey, mappedvalue in self._store.values())
+
+    def __len__(self):
+        return len(self._store)
+
+    def lower_items(self):
+        """Like iteritems(), but with all lowercase keys."""
+        return (
+            (lowerkey, keyval[1])
+            for (lowerkey, keyval)
+            in self._store.items()
+        )
+
+    def __eq__(self, other):
+        if isinstance(other, Mapping):
+            other = CaseInsensitiveDict(other)
+        else:
+            return NotImplemented
+        # Compare insensitively
+        return dict(self.lower_items()) == dict(other.lower_items())
+
+    # Copy is required
+    def copy(self):
+        return CaseInsensitiveDict(self._store.values())
+
+    def __repr__(self):
+        return str(dict(self.items()))
 
 
 SUPPORTED_DRIVERS = CaseInsensitiveDict(

--- a/pytest_selenium/safety.py
+++ b/pytest_selenium/safety.py
@@ -7,7 +7,6 @@ import os
 import re
 
 import pytest
-import requests
 
 
 def pytest_addoption(parser):
@@ -53,6 +52,11 @@ def sensitive_url(request, base_url):
     """Return the first sensitive URL from response history of the base URL"""
     if not base_url:
         return False
+
+    # import requests lazily here to avoid importing
+    # requests for unit tests that don't need it
+    import requests
+
     # consider this environment sensitive if the base url or any redirection
     # history matches the regular expression
     urls = [base_url]


### PR DESCRIPTION
The import of requests is pretty expensive, and if pytest-selenium is just installed as a plugin we incur the overhead for that, even though we're running unit tests that don't need it. 

The moved imports and copied CaseInsensitiveDict is a bit uglier but saves 0.1-0.2 seconds on my machine. 