### PR TITLE
PhantomJS driver will be removed in selenium 4.0.0

### DIFF
--- a/pytest_selenium/pytest_selenium.py
+++ b/pytest_selenium/pytest_selenium.py
@@ -5,12 +5,14 @@
 import argparse
 import copy
 from datetime import datetime
+from distutils.version import LooseVersion
 import os
 import io
 import logging
 
 import pytest
 from requests.structures import CaseInsensitiveDict
+from selenium import __version__ as SELENIUM_VERSION
 from selenium import webdriver
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.support.event_firing_webdriver import EventFiringWebDriver
@@ -28,13 +30,17 @@ SUPPORTED_DRIVERS = CaseInsensitiveDict(
         "Edge": webdriver.Edge,
         "Firefox": webdriver.Firefox,
         "IE": webdriver.Ie,
-        "PhantomJS": webdriver.PhantomJS,
         "Remote": webdriver.Remote,
         "Safari": webdriver.Safari,
         "SauceLabs": webdriver.Remote,
         "TestingBot": webdriver.Remote,
     }
 )
+
+
+# Selenium 4.0.0 deprecated phantom js.
+if LooseVersion(SELENIUM_VERSION) < LooseVersion("4.0.0"):
+    SUPPORTED_DRIVERS["PhantomJS"] = webdriver.PhantomJS
 
 try:
     from appium import webdriver as appiumdriver

--- a/testing/test_phantomjs.py
+++ b/testing/test_phantomjs.py
@@ -3,8 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
+from distutils.version import LooseVersion
 
 import pytest
+from selenium import __version__ as SELENIUM_VERSION
 
 pytestmark = pytest.mark.nondestructive
 
@@ -20,7 +22,11 @@ def test_launch(testdir, httpserver):
             assert webtext == u'Success!'
     """
     )
-    testdir.quick_qa("--driver", "PhantomJS", file_test, passed=1)
+    if LooseVersion(SELENIUM_VERSION) < LooseVersion("4.0.0"):
+        testdir.quick_qa("--driver", "PhantomJS", file_test, passed=1)
+    else:
+        reprec = testdir.inline_run("--driver", "PhantomJS")
+        assert reprec.ret == pytest.ExitCode.USAGE_ERROR
 
 
 @pytest.mark.phantomjs
@@ -36,5 +42,8 @@ def test_args(testdir):
         def test_pass(selenium): pass
     """
     )
-    testdir.quick_qa("--driver", "PhantomJS", file_test, passed=1)
-    assert os.path.exists(str(testdir.tmpdir.join("foo.log")))
+    if LooseVersion(SELENIUM_VERSION) < LooseVersion("4.0.0"):
+        testdir.quick_qa("--driver", "PhantomJS", file_test, passed=1)
+        assert os.path.exists(str(testdir.tmpdir.join("foo.log")))
+    else:
+        pass


### PR DESCRIPTION
Prepare for the deprecation of PhantomJS driver in selenium 4.0.0 release: https://github.com/SeleniumHQ/selenium/commit/8959a2872b4ae19163aa1c9cd78dbc238763500b

Failing tests fixed in: https://github.com/pytest-dev/pytest-selenium/pull/240