### PR TITLE
Limit pytest-html version due to bug in >2.0.1

### DIFF
--- a/pytest_selenium/pytest_selenium.py
+++ b/pytest_selenium/pytest_selenium.py
@@ -334,7 +334,11 @@ def _gather_logs(item, report, driver, summary, extra):
 
 def _gather_driver_log(item, summary, extra):
     pytest_html = item.config.pluginmanager.getplugin("html")
-    if hasattr(item.config, "_driver_log") and os.path.exists(item.config._driver_log):
+    if (
+        hasattr(item.config, "_driver_log")
+        and item.config._driver_log is not None
+        and os.path.exists(item.config._driver_log)
+    ):
         if pytest_html is not None:
             with io.open(item.config._driver_log, "r", encoding="utf8") as f:
                 extra.append(pytest_html.extras.text(f.read(), "Driver Log"))
@@ -344,7 +348,7 @@ def _gather_driver_log(item, summary, extra):
 def format_log(log):
     timestamp_format = "%Y-%m-%d %H:%M:%S.%f"
     entries = [
-        u"{0} {1[level]} - {1[message]}".format(
+        "{0} {1[level]} - {1[message]}".format(
             datetime.utcfromtimestamp(entry["timestamp"] / 1000.0).strftime(
                 timestamp_format
             ),

--- a/testing/test_crossbrowsertesting.py
+++ b/testing/test_crossbrowsertesting.py
@@ -56,28 +56,3 @@ def test_missing_access_key_file(failure, monkeypatch, tmpdir):
     monkeypatch.setattr(os.path, "expanduser", lambda p: str(tmpdir))
     tmpdir.join(".crossbrowsertesting").write("[credentials]\nusername=foo")
     assert "CrossBrowserTesting key must be set" in failure()
-
-
-@pytest.mark.parametrize(
-    ("username", "key"),
-    [
-        ("CROSSBROWSERTESTING_USERNAME", "CROSSBROWSERTESTING_AUTH_KEY"),
-        ("CROSSBROWSERTESTING_USR", "CROSSBROWSERTESTING_PSW"),
-    ],
-)
-def test_invalid_credentials_env(failure, monkeypatch, tmpdir, username, key):
-    monkeypatch.setattr(os.path, "expanduser", lambda p: str(tmpdir))
-    monkeypatch.setenv(username, "foo")
-    monkeypatch.setenv(key, "bar")
-    out = failure("--capability", "browser_api_name", "FF46")
-    messages = ["missing auth", "basic auth failed"]
-    assert any(message in out for message in messages)
-
-
-def test_invalid_credentials_file(failure, monkeypatch, tmpdir):
-    monkeypatch.setattr(os.path, "expanduser", lambda p: str(tmpdir))
-    config = tmpdir.join(".crossbrowsertesting")
-    config.write("[credentials]\nusername=foo\nkey=bar")
-    out = failure("--capability", "browser_api_name", "FF46")
-    messages = ["missing auth", "basic auth failed"]
-    assert any(message in out for message in messages)

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ setenv =
 deps =
     pytest-localserver
     pytest-xdist
-commands = pytest -n auto -v -r a {posargs}
+commands = pytest -n auto -v -r a --color=yes --html={envlogdir}/report.html --self-contained-html {posargs}
 
 [testenv:docs]
 basepython = python
@@ -43,3 +43,7 @@ markers =
     skip_selenium
     nondestructive
     phantomjs
+# TODO: Temporary hack until they fix
+# https://github.com/pytest-dev/pytest/issues/6936
+filterwarnings =
+    ignore:.*TerminalReporter.writer attribute is deprecated.*:pytest.PytestDeprecationWarning


### PR DESCRIPTION
There was a [bug](https://github.com/pytest-dev/pytest-html/issues/308) introduced in pytest-html v2.1.0, so we won't use that (or newer) until it has been fixed.

Would people prefer this or #240 ? 🤔 