### PR TITLE
Feature/edge chromium

### DIFF
--- a/pytest_selenium/drivers/edge.py
+++ b/pytest_selenium/drivers/edge.py
@@ -2,10 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 from distutils.version import LooseVersion
+
+import pytest
 from selenium import __version__ as SELENIUM_VERSION
+from selenium.webdriver.edge.options import Options
 
 
-def driver_kwargs(capabilities, driver_log, driver_path, **kwargs):
+def driver_kwargs(capabilities, driver_log, driver_path, edge_options, **kwargs):
 
     # Selenium 3.14.0 deprecated log_path in favour of service_log_path
     if LooseVersion(SELENIUM_VERSION) < LooseVersion("3.14.0"):
@@ -13,8 +16,17 @@ def driver_kwargs(capabilities, driver_log, driver_path, **kwargs):
     else:
         kwargs = {"service_log_path": driver_log}
 
+    if LooseVersion(SELENIUM_VERSION) >= LooseVersion("4.0.0"):
+        kwargs["options"] = edge_options
+
     if capabilities:
         kwargs["capabilities"] = capabilities
     if driver_path is not None:
         kwargs["executable_path"] = driver_path
+
     return kwargs
+
+
+@pytest.fixture
+def edge_options():
+    return Options()

--- a/pytest_selenium/pytest_selenium.py
+++ b/pytest_selenium/pytest_selenium.py
@@ -96,7 +96,12 @@ def session_capabilities(pytestconfig):
 
 @pytest.fixture
 def capabilities(
-    request, driver_class, chrome_options, firefox_options, session_capabilities
+    request,
+    driver_class,
+    chrome_options,
+    firefox_options,
+    edge_options,
+    session_capabilities,
 ):
     """Returns combined capabilities"""
     capabilities = copy.deepcopy(session_capabilities)  # make a copy
@@ -111,6 +116,9 @@ def capabilities(
         elif browser == "FIREFOX":
             key = firefox_options.KEY
             options = firefox_options.to_capabilities()
+        elif browser == "EDGE":
+            key = edge_options.KEY
+            options = edge_options.to_capabilities()
         if all([key, options]):
             capabilities[key] = _merge(capabilities.get(key, {}), options.get(key, {}))
     capabilities.update(get_capabilities_from_markers(request.node))
@@ -146,6 +154,7 @@ def driver_kwargs(
     driver_path,
     firefox_options,
     firefox_profile,
+    edge_options,
     pytestconfig,
 ):
     kwargs = {}
@@ -159,6 +168,7 @@ def driver_kwargs(
             driver_path=driver_path,
             firefox_options=firefox_options,
             firefox_profile=firefox_profile,
+            edge_options=edge_options,
             host=pytestconfig.getoption("host"),
             port=pytestconfig.getoption("port"),
             service_log_path=None,
@@ -166,6 +176,7 @@ def driver_kwargs(
             test=".".join(split_class_and_test_names(request.node.nodeid)),
         )
     )
+
     pytestconfig._driver_log = driver_log
     return kwargs
 

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -52,6 +52,8 @@ def testdir(request, httpserver_base_url):
             error::DeprecationWarning
             ignore:--firefox-\w+ has been deprecated:DeprecationWarning
             ignore:Support for PhantomJS:DeprecationWarning
+            ignore:desired_capabilities has been deprecated
+            ignore:service_log_path has been deprecated
     """,
     )
 

--- a/testing/test_edge.py
+++ b/testing/test_edge.py
@@ -4,13 +4,16 @@
 
 import pytest
 import sys
+from distutils.version import LooseVersion
+from selenium import __version__ as SELENIUM_VERSION
+
 
 pytestmark = pytest.mark.nondestructive
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Edge only runs on Windows")
 @pytest.mark.edge
-def test_launch(testdir, httpserver):
+def test_launch_legacy(testdir, httpserver):
     httpserver.serve_content(content="<h1>Success!</h1>")
     file_test = testdir.makepyfile(
         """
@@ -18,6 +21,32 @@ def test_launch(testdir, httpserver):
         @pytest.mark.nondestructive
         def test_pass(webtext):
             assert webtext == u'Success!'
+    """
+    )
+    testdir.quick_qa("--driver", "Edge", file_test, passed=1)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Edge only runs on Windows")
+@pytest.mark.skipif(
+    LooseVersion(SELENIUM_VERSION) < LooseVersion("4.0.0"),
+    reason="Edge chromium only supported for selenium >= 4.0.0",
+)
+@pytest.mark.edge
+@pytest.mark.parametrize("use_chromium", [True, False], ids=["chromium", "legacy"])
+def test_launch(use_chromium, testdir, httpserver):
+    httpserver.serve_content(content="<h1>Success!</h1>")
+    file_test = testdir.makepyfile(
+        f"""
+        import pytest
+
+        @pytest.mark.nondestructive
+        def test_pass(webtext):
+            assert webtext == u'Success!'
+
+        @pytest.fixture
+        def edge_options(edge_options):
+            edge_options.use_chromium = {use_chromium}
+            return edge_options
     """
     )
     testdir.quick_qa("--driver", "Edge", file_test, passed=1)

--- a/testing/test_edge.py
+++ b/testing/test_edge.py
@@ -36,7 +36,7 @@ def test_launch_legacy(testdir, httpserver):
 def test_launch(use_chromium, testdir, httpserver):
     httpserver.serve_content(content="<h1>Success!</h1>")
     file_test = testdir.makepyfile(
-        f"""
+        """
         import pytest
 
         @pytest.mark.nondestructive
@@ -45,8 +45,10 @@ def test_launch(use_chromium, testdir, httpserver):
 
         @pytest.fixture
         def edge_options(edge_options):
-            edge_options.use_chromium = {use_chromium}
+            edge_options.use_chromium = {}
             return edge_options
-    """
+    """.format(
+            use_chromium
+        )
     )
     testdir.quick_qa("--driver", "Edge", file_test, passed=1)


### PR DESCRIPTION
Added edge options fixture.

https://github.com/pytest-dev/pytest-selenium/issues/235

The added tests are currently failing due to a bug in selenium https://github.com/SeleniumHQ/selenium/issues/8459
So I will have to wait for the next alpha release to test it. But backwards compatibility should be ensured.

I ignored the deprecation warnings about the Service object but this should be fixed in another MR (The warning will be released with selenium 4.0.0) at some point.

Merging this should probably be done after the selenium 4.0.0 release