### PR TITLE
Wheel is no longer universal

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1


### PR DESCRIPTION
Since we dropped Python 2.7, pytest-selenium wheels should not longer be considered universal.