### PR TITLE
Rename host and port arguments for GRID

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -248,11 +248,11 @@ driver, as the accepted capabilities may differ::
   pytest --driver Remote --capability browserName firefox
 
 Note that if your server is not running locally or is running on an alternate
-port you will need to specify the ``--host`` and ``--port`` command line
+port you will need to specify the ``--selenium-host`` and ``--selenium-port`` command line
 options, or by setting the ``SELENIUM_HOST`` and ``SELENIUM_PORT`` environment
 variables::
 
-  pytest --driver Remote --host selenium.hostname --port 5555 --capability browserName firefox
+  pytest --driver Remote --selenium-host selenium.hostname --selenium-port 5555 --capability browserName firefox
 
 Sauce Labs
 ----------
@@ -428,7 +428,7 @@ Local tunnel
 ~~~~~~~~~~~~
 
 To run the tests using `TestingBot's local tunnel <https://testingbot.com/support/other/tunnel>`_
-you'll also need to set the ``--host`` and ``--port`` command line arguments.
+you'll also need to set the ``--selenium-host`` and ``--selenium-port`` command line arguments.
 
 CrossBrowserTesting
 -------------------
@@ -493,11 +493,11 @@ selection is determined using capabilities. Check the
 for details of accepted values.
 
 Note that if your Appium server is not running locally or is running on an
-alternate port you will need to specify the ``--host`` and ``--port``
+alternate port you will need to specify the ``--selenium-host`` and ``--selenium-port``
 command line options, or by setting the ``APPIUM_HOST`` and ``APPIUM_PORT``
 environment variables::
 
-  pytest --driver Appium --host appium.hostname --port 5555
+  pytest --driver Appium --selenium-host appium.hostname --selenium-port 5555
 
 Specifying Capabilities
 ***********************

--- a/testing/test_driver.py
+++ b/testing/test_driver.py
@@ -106,7 +106,11 @@ def test_default_host_port(testdir):
     testdir.quick_qa("--driver", "Remote", file_test, passed=1)
 
 
-def test_arguments_order(testdir):
+@pytest.mark.parametrize(
+    ("host_arg_name", "port_arg_name"),
+    [("--selenium-host", "--selenium-port"), ("--host", "--port")],
+)
+def test_arguments_order(testdir, host_arg_name, port_arg_name):
     host = "notlocalhost"
     port = "4441"
     file_test = testdir.makepyfile(
@@ -120,7 +124,14 @@ def test_arguments_order(testdir):
         )
     )
     testdir.quick_qa(
-        "--driver", "Remote", "--host", host, "--port", port, file_test, passed=1
+        "--driver",
+        "Remote",
+        host_arg_name,
+        host,
+        port_arg_name,
+        port,
+        file_test,
+        passed=1,
     )
 
 
@@ -138,7 +149,14 @@ def test_arguments_order_random(testdir):
         )
     )
     testdir.quick_qa(
-        "--host", host, "--driver", "Remote", "--port", port, file_test, passed=1
+        "--selenium-host",
+        host,
+        "--driver",
+        "Remote",
+        "--selenium-port",
+        port,
+        file_test,
+        passed=1,
     )
 
 

--- a/testing/test_metadata.py
+++ b/testing/test_metadata.py
@@ -23,7 +23,11 @@ def test_metadata_default_host_port(testdir):
     testdir.quick_qa("--driver", "Remote", file_test, passed=1)
 
 
-def test_metadata_host_port(testdir):
+@pytest.mark.parametrize(
+    ("host_arg_name", "port_arg_name"),
+    [("--selenium-host", "--selenium-port"), ("--host", "--port")],
+)
+def test_metadata_host_port(testdir, host_arg_name, port_arg_name):
     host = "notlocalhost"
     port = "4441"
     file_test = testdir.makepyfile(
@@ -37,5 +41,12 @@ def test_metadata_host_port(testdir):
         )
     )
     testdir.quick_qa(
-        "--driver", "Remote", "--host", host, "--port", port, file_test, passed=1
+        "--driver",
+        "Remote",
+        host_arg_name,
+        host,
+        port_arg_name,
+        port,
+        file_test,
+        passed=1,
     )

--- a/testing/test_testingbot.py
+++ b/testing/test_testingbot.py
@@ -85,7 +85,7 @@ def test_invalid_credentials_file(failure, monkeypatch, tmpdir):
 def test_invalid_host(failure, monkeypatch, tmpdir):
     monkeypatch.setattr(os.path, "expanduser", lambda p: str(tmpdir))
     tmpdir.join(".testingbot").write("[credentials]\nkey=foo\nsecret=bar")
-    out = failure("--host", "foo.bar.com")
+    out = failure("--selenium-host", "foo.bar.com")
     messages = [
         "nodename nor servname provided, or not known",
         "Name or service not known",


### PR DESCRIPTION
Rename the Selenium GRID `--host` and `--port` to `--grid-host` and `--grid-port` respectively, to be more verbose and avoid collisions with other plugins.

See comment [here](https://github.com/pytest-dev/pytest-selenium/issues/215#issuecomment-676907505).