### PR TITLE
Browserstack little improvements and Edge fix about options

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -378,6 +378,24 @@ See the
 for additional configuration that can be set using ``--capability`` command line
 arguments.
 
+Test result links
+~~~~~~~~~~~~~~~~~
+
+By default, links to BrowserStack jobs are only visible to users logged in to the account
+that ran the job. You can choose to display a public URL in the pytest summary.
+
+This can be configured by setting the ``BROWSERSTACK_JOB_ACCESS`` environment variable or by
+adding ``report`` section in ``.browserstack`` configuration file.
+Allowed values are ``browser_url`` for private access and ``public_url`` for everyone.
+
+An example using a configuration file:
+
+.. code-block:: ini
+
+  [report]
+  job_access = browser_url
+
+
 TestingBot
 ----------
 

--- a/pytest_selenium/drivers/browserstack.py
+++ b/pytest_selenium/drivers/browserstack.py
@@ -9,7 +9,7 @@ from pytest_selenium.drivers.cloud import Provider
 
 class BrowserStack(Provider):
 
-    API = "https://www.browserstack.com/automate/sessions/{session}.json"
+    API = "https://api.browserstack.com/automate/sessions/{session}.json"
 
     @property
     def auth(self):

--- a/pytest_selenium/drivers/browserstack.py
+++ b/pytest_selenium/drivers/browserstack.py
@@ -5,6 +5,7 @@
 import pytest
 
 from pytest_selenium.drivers.cloud import Provider
+from pytest_selenium.exceptions import MissingCloudSettingError
 
 
 class BrowserStack(Provider):
@@ -31,6 +32,21 @@ class BrowserStack(Provider):
             "key", ["BROWSERSTACK_ACCESS_KEY", "BROWSERSTACK_PSW"]
         )
 
+    @property
+    def job_access(self):
+        """Get job url field, private(required authentication) or public."""
+        try:
+            field = self.get_setting(
+                key="job_access",
+                envs=["BROWSERSTACK_JOB_ACCESS"],
+                section="report",
+                allowed_values=["browser_url", "public_url"],
+            )
+        except MissingCloudSettingError:
+            field = "browser_url"
+
+        return field
+
 
 @pytest.mark.optionalhook
 def pytest_selenium_runtest_makereport(item, report, summary, extra):
@@ -47,7 +63,7 @@ def pytest_selenium_runtest_makereport(item, report, summary, extra):
 
     try:
         job_info = requests.get(api_url, auth=provider.auth, timeout=10).json()
-        job_url = job_info["automation_session"]["browser_url"]
+        job_url = job_info["automation_session"][provider.job_access]
         # Add the job URL to the summary
         summary.append("{0} Job: {1}".format(provider.name, job_url))
         pytest_html = item.config.pluginmanager.getplugin("html")
@@ -79,6 +95,7 @@ def pytest_selenium_runtest_makereport(item, report, summary, extra):
 
 def driver_kwargs(request, test, capabilities, **kwargs):
     provider = BrowserStack()
+    assert provider.job_access
     capabilities.setdefault("name", test)
     capabilities.setdefault("browserstack.user", provider.username)
     capabilities.setdefault("browserstack.key", provider.key)

--- a/pytest_selenium/exceptions.py
+++ b/pytest_selenium/exceptions.py
@@ -5,10 +5,22 @@
 import pytest
 
 
-class MissingCloudCredentialError(pytest.UsageError):
+class MissingCloudSettingError(pytest.UsageError):
     def __init__(self, driver, key, envs):
-        super(MissingCloudCredentialError, self).__init__(
+        super(MissingCloudSettingError, self).__init__(
             "{0} {1} must be set. Try setting one of the following "
             "environment variables {2}, or see the documentation for "
             "how to use a configuration file.".format(driver, key, envs)
+        )
+
+
+class MissingCloudCredentialError(MissingCloudSettingError):
+    pass
+
+
+class InvalidCloudSettingError(pytest.UsageError):
+    def __init__(self, driver, key, value):
+        super(InvalidCloudSettingError, self).__init__(
+            "{0} {1} invalid value `{2}`, see the documentation for how "
+            "to use this parameter.".format(driver, key, value)
         )

--- a/pytest_selenium/pytest_selenium.py
+++ b/pytest_selenium/pytest_selenium.py
@@ -112,7 +112,7 @@ def capabilities(
             key = firefox_options.KEY
             options = firefox_options.to_capabilities()
         elif browser == "EDGE":
-            key = edge_options.KEY
+            key = getattr(edge_options, "KEY", None)
             options = edge_options.to_capabilities()
         if all([key, options]):
             capabilities[key] = _merge(capabilities.get(key, {}), options.get(key, {}))

--- a/testing/test_browserstack.py
+++ b/testing/test_browserstack.py
@@ -80,3 +80,9 @@ def test_invalid_credentials_file(failure, monkeypatch, tmpdir):
     out = failure()
     messages = ["Invalid username or password", "basic auth failed"]
     assert any(message in out for message in messages)
+
+
+def test_invalid_job_access_value(failure, monkeypatch, tmpdir):
+    monkeypatch.setattr(os.path, "expanduser", lambda p: str(tmpdir))
+    tmpdir.join(".browserstack").write("[report]\njob_access=foo")
+    assert "BrowserStack job_access invalid value `foo`" in failure()


### PR DESCRIPTION
A mixed MR for a better integration with BrowserStack.

Browserstack report is available from 2 URLs private or public. A static variable is added with a default value to keep backward compatibility with `browser_url`. Now users can override the URL field with `public_url`.

More details in commit messages.


