### PR TITLE
adding support for additional sauce endpoints

### DIFF
--- a/pytest_selenium/pytest_selenium.py
+++ b/pytest_selenium/pytest_selenium.py
@@ -441,6 +441,15 @@ def pytest_addoption(parser):
         default=os.getenv("SAUCELABS_JOB_AUTH", "none"),
     )
 
+    _data_centre_choices = ("us-west-1", "eu-central-1")
+    parser.addini(
+        "saucelabs_data_centre",
+        help="Data centre options for Sauce Labs connections {0}".format(
+            _data_centre_choices
+        ),
+        default="us-west-1",
+    )
+
     parser.addini(
         "max_driver_init_attempts",
         help="Maximum number of driver initialization attempts",

--- a/testing/test_saucelabs.py
+++ b/testing/test_saucelabs.py
@@ -211,12 +211,23 @@ def test_auth_type_expiration(monkeypatch, auth_type):
     assert re.match(expected_pattern, actual)
 
 
+def test_default_data_centre(monkeypatch):
+    from pytest_selenium.drivers.saucelabs import SauceLabs
+
+    provider = SauceLabs()
+
+    expected = "us-west-1"
+    actual = provider.data_centre
+
+    assert expected in actual
+
+
 class Config(object):
     def __init__(self, value):
         self._value = value
 
     def getini(self, key):
-        if key == "saucelabs_job_auth":
+        if key == "saucelabs_job_auth" or "sauce_labs_data_centre":
             return self._value
         else:
             raise KeyError


### PR DESCRIPTION
Recently Sauce has added [multiple data centres](https://docs.saucelabs.com/basics/data-center-endpoints/data-center-endpoints/index.html#endpoints) and as such, now require additional values for some endpoints for both its API and Selenium hub URLs. 

On behalf of Sauce Labs, I'm adding support for these data centres.