### PR TITLE
Session Scope Fixture CLI Option

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-pytest = "*"
+pytest = ">= 5.2.0"
 tox = "*"
 flake8 = "*"
 black = "*"

--- a/README.rst
+++ b/README.rst
@@ -25,14 +25,6 @@ support for running `Selenium <http://seleniumhq.org/>`_ based tests.
    :target: https://requires.io/github/pytest-dev/pytest-selenium/requirements/?branch=master
    :alt: Requirements
 
-Development
-------------
-To install the development dependencies locally you'll need to run Pipenv like this:
-
-    ``pipenv lock --dev --pre``
-
-This is because ``black`` is still in a pre-release state.
-
 Resources
 ---------
 

--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,14 @@ support for running `Selenium <http://seleniumhq.org/>`_ based tests.
    :target: https://requires.io/github/pytest-dev/pytest-selenium/requirements/?branch=master
    :alt: Requirements
 
+Development
+------------
+To install the development dependencies locally you'll need to run Pipenv like this:
+
+    ``pipenv lock --dev --pre``
+
+This is because ``black`` is still in a pre-release state.
+
 Resources
 ---------
 

--- a/pytest_selenium/drivers/chrome.py
+++ b/pytest_selenium/drivers/chrome.py
@@ -7,6 +7,8 @@ import pytest
 from selenium import __version__ as SELENIUM_VERSION
 from selenium.webdriver.chrome.options import Options
 
+from pytest_selenium.pytest_selenium import determine_scope
+
 
 def driver_kwargs(
     capabilities, driver_args, driver_log, driver_path, chrome_options, **kwargs
@@ -26,6 +28,6 @@ def driver_kwargs(
     return kwargs
 
 
-@pytest.fixture
+@pytest.fixture(scope=determine_scope)
 def chrome_options():
     return Options()

--- a/pytest_selenium/drivers/edge.py
+++ b/pytest_selenium/drivers/edge.py
@@ -7,6 +7,8 @@ import pytest
 from selenium import __version__ as SELENIUM_VERSION
 from selenium.webdriver.edge.options import Options
 
+from pytest_selenium.pytest_selenium import determine_scope
+
 
 def driver_kwargs(capabilities, driver_log, driver_path, edge_options, **kwargs):
 
@@ -27,6 +29,6 @@ def driver_kwargs(capabilities, driver_log, driver_path, edge_options, **kwargs)
     return kwargs
 
 
-@pytest.fixture
+@pytest.fixture(scope=determine_scope)
 def edge_options():
     return Options()

--- a/pytest_selenium/drivers/firefox.py
+++ b/pytest_selenium/drivers/firefox.py
@@ -11,6 +11,8 @@ from selenium.webdriver import FirefoxProfile
 from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 from selenium.webdriver.firefox.options import Options
 
+from pytest_selenium.pytest_selenium import determine_scope
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -78,7 +80,7 @@ def driver_kwargs(capabilities, driver_log, driver_path, firefox_options, **kwar
     return kwargs
 
 
-@pytest.fixture
+@pytest.fixture(scope=determine_scope)
 def firefox_options(request, firefox_path, firefox_profile):
     options = Options()
 
@@ -111,7 +113,7 @@ def get_preferences_from_markers(node):
     return preferences
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope=determine_scope)
 def firefox_path(pytestconfig):
     if pytestconfig.getoption("firefox_path"):
         warnings.warn(
@@ -125,7 +127,7 @@ def firefox_path(pytestconfig):
         return pytestconfig.getoption("firefox_path")
 
 
-@pytest.fixture
+@pytest.fixture(scope=determine_scope)
 def firefox_profile(pytestconfig):
     profile = None
     if pytestconfig.getoption("firefox_profile"):

--- a/pytest_selenium/hooks.py
+++ b/pytest_selenium/hooks.py
@@ -4,8 +4,8 @@
 
 
 def pytest_selenium_capture_debug(item, report, extra):
-    """ Called when gathering debug information for the HTML report. """
+    """Called when gathering debug information for the HTML report."""
 
 
 def pytest_selenium_runtest_makereport(item, report, summary, extra):
-    """ Called when making the HTML report. """
+    """Called when making the HTML report."""

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     url="https://github.com/pytest-dev/pytest-selenium",
     packages=["pytest_selenium", "pytest_selenium.drivers"],
     install_requires=[
-        "pytest>=5.0.0",
+        "pytest>=5.2.0",
         "pytest-base-url",
         "pytest-html>=1.14.0",
         "pytest-variables>=1.5.0",

--- a/testing/test_capabilities.py
+++ b/testing/test_capabilities.py
@@ -21,6 +21,18 @@ def testfile(testdir):
     )
 
 
+@pytest.fixture
+def testfile_scopes(testdir):
+    return testdir.makepyfile(
+        """
+        import pytest
+        @pytest.mark.nondestructive
+        def test_chrome_options(chrome_options):
+            assert chrome_options
+    """
+    )
+
+
 def test_command_line(testfile, testdir):
     testdir.quick_qa("--capability", "foo", "bar", testfile, passed=1)
 
@@ -62,6 +74,22 @@ def test_fixture(testfile, testdir):
     """
     )
     testdir.quick_qa(testfile, passed=1)
+
+
+def test_session_scoped_fixture(testfile_scopes, testdir):
+    testdir.makeconftest(
+        """
+        import pytest
+        @pytest.fixture(scope='session')
+        def chrome_options(chrome_options):
+            chrome_options.add_argument('--headless')
+            return chrome_options
+    """
+    )
+    testdir.quick_qa(testfile_scopes, failed=1)
+    testdir.quick_qa(
+        "--selenium-session-scope", testfile_scopes, passed=1
+    )
 
 
 def test_mark(testdir):


### PR DESCRIPTION
Per the explanation on this issue: https://github.com/pytest-dev/pytest-selenium/issues/273

Driven by a need to perform a large number of regression tests on a legacy app by obtaining a cookie using Selenium and then essentially calling the app's API end-points to run actual tests I wanted to be able to have the Selenium fixture last the whole test session as it is by far the slowest part of any given test.

Hopefully folks are happy with this approach. Please let me know if there might a preferred method to solve this problem.

Thanks!