### PR TITLE
Handle non W3C caps for browserstack

### DIFF
--- a/src/pytest_selenium/drivers/browserstack.py
+++ b/src/pytest_selenium/drivers/browserstack.py
@@ -18,7 +18,7 @@ class BrowserStack(Provider):
 
     @property
     def executor(self):
-        return "https://hub-cloud.browserstack.com/wd/hub"
+        return "https://hub.browserstack.com/wd/hub"
 
     @property
     def username(self):

--- a/src/pytest_selenium/drivers/browserstack.py
+++ b/src/pytest_selenium/drivers/browserstack.py
@@ -96,7 +96,10 @@ def pytest_selenium_runtest_makereport(item, report, summary, extra):
 def driver_kwargs(request, test, capabilities, **kwargs):
     provider = BrowserStack()
     assert provider.job_access
-    if "bstack:options" in capabilities and type(capabilities["bstack:options"]) is dict:
+    if (
+        "bstack:options" in capabilities
+        and type(capabilities["bstack:options"]) is dict
+    ):
         capabilities["bstack:options"].setdefault("sessionName", test)
         capabilities["bstack:options"].setdefault("userName", provider.username)
         capabilities["bstack:options"].setdefault("accessKey", provider.key)

--- a/src/pytest_selenium/drivers/browserstack.py
+++ b/src/pytest_selenium/drivers/browserstack.py
@@ -96,9 +96,14 @@ def pytest_selenium_runtest_makereport(item, report, summary, extra):
 def driver_kwargs(request, test, capabilities, **kwargs):
     provider = BrowserStack()
     assert provider.job_access
-    capabilities.setdefault("name", test)
-    capabilities.setdefault("browserstack.user", provider.username)
-    capabilities.setdefault("browserstack.key", provider.key)
+    if "bstack:options" in capabilities and type(capabilities["bstack:options"]) is dict:
+        capabilities["bstack:options"].setdefault("sessionName", test)
+        capabilities["bstack:options"].setdefault("userName", provider.username)
+        capabilities["bstack:options"].setdefault("accessKey", provider.key)
+    else:
+        capabilities.setdefault("name", test)
+        capabilities.setdefault("browserstack.user", provider.username)
+        capabilities.setdefault("browserstack.key", provider.key)
     kwargs = {
         "command_executor": provider.executor,
         "desired_capabilities": capabilities,


### PR DESCRIPTION
When using the `--driver Browserstack` CLI flag, the default caps - `name`, `browserstack.user` and `browserstack.key` are added to capabilities. These caps are not W3C spec compliant (according to which all vendor specific caps should be inside `vendor:options`). Moving these caps inside `bstack:options` with this PR.