### PR TITLE
Chore: Disable scheduled actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - master
 
-  schedule:
-    - cron: '0 18 * * *'  # Run daily at 14:00 UTC
+#  schedule:
+#    - cron: '0 18 * * *'  # Run daily at 14:00 UTC
 
   pull_request:
 
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   linting:
+    if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository == 'pytest-dev/pytest-selenium')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Disabling scheduled github action runs for now, for two reasons:

1. They also run on forks - massive waste of resources and huge annoyance to contributors (SORRY!)
2. Due to the breaking change introduced in selenium 4.10 causing said scheduled runs to fail.